### PR TITLE
chore: cleanup `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,13 @@
-# Sub-modules
-###################
+# STM32CubeIDE Artifacts #
+##########################
 Application/STM32CubeIDE/Debug*
 Application/STM32CubeIDE/Release*
 Application/STM32CubeIDE/.settings
 Application/STM32CubeIDE/sparrow.launch
+
+# Sub-modules #
+###############
+note-c/
 
 # Compiled source #
 ###################
@@ -17,8 +21,8 @@ Application/STM32CubeIDE/sparrow.launch
 *.a
 *.pbi
 
-# auto- generated files #
-######################
+# Auto-generated files #
+########################
 *~
 \#*\#
 .DS_Store


### PR DESCRIPTION
Adding `note-c` to `.gitignore`.

I think it was originally there. I believe it was removed to make way for the submodule that we punted on, but was never put back in place.

I discovered this oversight when I cloned and setup `sparrow-lora` in STM32CubeIDE from scratch to document the process.