### PR TITLE
chore: Remove `registerSensors` artifacts

### DIFF
--- a/Application/Sensor/init.c
+++ b/Application/Sensor/init.c
@@ -14,8 +14,8 @@
 #define USE_PING_TEST               false
 #endif
 
-// Initialize sensors
-void initSensors()
+// Initialize sensors (enable external project override)
+__weak void initSensors()
 {
 
     // Handles the Bosch BME280 temp/humidity/pressure sensor
@@ -38,10 +38,4 @@ void initSensors()
     pingInit();
 #endif
 
-    // Entrypoint for user-defined sensors to be registered
-    registerSensors();
-
 }
-
-// To be user-defined else no-op
-__weak int registerSensors (void) { return 0; }

--- a/Application/Sensor/sensor.h
+++ b/Application/Sensor/sensor.h
@@ -70,7 +70,6 @@ struct sensorConfig_c {
 
 // init.c
 void initSensors(void);
-int registerSensors (void);
 
 // Sensor init methods
 bool bmeInit(void);


### PR DESCRIPTION
Functionality replaced by repurposing existing `initSensors` function