### PR TITLE
feat: Application Context

### DIFF
--- a/Application/Framework/sched.c
+++ b/Application/Framework/sched.c
@@ -114,7 +114,7 @@ void schedDispatchISR(uint16_t pins)
 {
     for (int i=0; i<apps; i++) {
         if (!state[i].disabled && config[i].interruptFn != NULL) {
-            config[i].interruptFn(i, pins);
+            config[i].interruptFn(i, pins, config[i].appContext);
         }
     }
 }
@@ -222,7 +222,7 @@ void schedResponseCompleted(J *rsp)
                 state[i].responsePending = false;
                 schedSetState(i, state[i].completionSuccessState, "response completed");
                 if (config[i].responseFn != NULL) {
-                    config[i].responseFn(i, rsp);
+                    config[i].responseFn(i, rsp, config[i].appContext);
                 }
             }
         }
@@ -352,10 +352,10 @@ uint32_t schedPoll()
     // Poll the active app
     for (int i=0; i<apps; i++) {
         if (!state[i].disabled && state[i].active && config[i].pollFn != NULL) {
-            config[i].pollFn(i, state[i].currentState);
+            config[i].pollFn(i, state[i].currentState, config[i].appContext);
             if (state[i].currentState == STATE_ONCE) {
                 state[i].currentState = STATE_ACTIVATED;
-                config[i].pollFn(i, state[i].currentState);
+                config[i].pollFn(i, state[i].currentState, config[i].appContext);
             }
             if (state[i].currentState == STATE_DEACTIVATED) {
 
@@ -416,7 +416,7 @@ uint32_t schedPoll()
         if (config[lastActiveApp].activateFn == NULL) {
             break;
         }
-        if (config[lastActiveApp].activateFn(lastActiveApp)) {
+        if (config[lastActiveApp].activateFn(lastActiveApp, config[lastActiveApp].appContext)) {
             break;
         }
 

--- a/Application/Framework/sched.h
+++ b/Application/Framework/sched.h
@@ -10,7 +10,7 @@
 // Called when time to activate; return false to cancel this activation.
 // Note that this method must not send messages to the gateway; it's only
 // allowed to do local operations.
-typedef bool (*schedActivateFunc) (int appID);
+typedef bool (*schedActivateFunc) (int appID, void *appContext);
 
 // Called repeatedly while activate; set to STATE_INACTIVE to deactivate.
 // This function implements the app's state machine, where negative
@@ -22,15 +22,15 @@ typedef bool (*schedActivateFunc) (int appID);
 #define STATE_DEACTIVATED           -4
 #define STATE_SENDING_REQUEST       -5
 #define STATE_RECEIVING_RESPONSE    -6
-typedef void (*schedPollFunc) (int appID, int state);
+typedef void (*schedPollFunc) (int appID, int state, void *appContext);
 
 // Called when an app does a notecard request and asynchronously receives
 // a reply.  This will be called when a response comes back or when it
 // times out; if timeout the "rsp" field will be null.
-typedef void (*schedResponseFunc) (int appID, J *rsp);
+typedef void (*schedResponseFunc) (int appID, J *rsp, void *appContext);
 
 // An ISR that is called on ANY+ALL interrupts; pins indicates exti lines that changed.
-typedef void (*schedInterruptFunc) (int appID, uint16_t pins);
+typedef void (*schedInterruptFunc) (int appID, uint16_t pins, void *appContext);
 
 // App Configuration definition
 typedef struct {
@@ -49,6 +49,9 @@ typedef struct {
     schedInterruptFunc interruptFn;
     schedPollFunc pollFn;
     schedResponseFunc responseFn;
+
+    // Application Context
+    void *appContext;
 
 } schedAppConfig;
 

--- a/Application/Sensor/bme.c
+++ b/Application/Sensor/bme.c
@@ -48,8 +48,8 @@ static int8_t bme280_i2c_write(uint8_t reg_addr, const uint8_t *reg_data, uint32
 static bool addNote(void);
 static bool registerNotefileTemplate(void);
 static bool bmeUpdate(void);
-static void bmePoll(int appID, int state);
-static void bmeResponse(int appID, J *rsp);
+static void bmePoll(int appID, int state, void *appContext);
+static void bmeResponse(int appID, J *rsp, void *appContext);
 
 // Scheduled App One-Time Init
 bool bmeInit()
@@ -64,6 +64,7 @@ bool bmeInit()
         .interruptFn = NULL,
         .pollFn = bmePoll,
         .responseFn = bmeResponse,
+        .appContext = NULL,
     };
     appID = schedRegisterApp(&config);
     if (appID < 0) {
@@ -92,7 +93,7 @@ bool bmeInit()
 }
 
 // Poller
-void bmePoll(int appID, int state)
+void bmePoll(int appID, int state, void *appContext)
 {
 
     // Disable if this isn't a reference sensor
@@ -167,7 +168,7 @@ static bool registerNotefileTemplate()
 }
 
 // Gateway Response handler
-void bmeResponse(int appID, J *rsp)
+void bmeResponse(int appID, J *rsp, void *appContext)
 {
 
     // If this is a response timeout, indicate as such

--- a/Application/Sensor/button.c
+++ b/Application/Sensor/button.c
@@ -14,9 +14,9 @@
 static int appID = -1;
 
 // Forwards
-static void buttonISR(int appID, uint16_t pins);
-static void buttonPoll(int appID, int state);
-static void buttonResponse(int appID, J *rsp);
+static void buttonISR(int appID, uint16_t pins, void *appContext);
+static void buttonPoll(int appID, int state, void *appContext);
+static void buttonResponse(int appID, J *rsp, void *appContext);
 static bool sendHealthLogMessage(bool immediate);
 
 // Scheduled App One-Time Init
@@ -32,6 +32,7 @@ bool buttonInit()
         .interruptFn = buttonISR,
         .pollFn = buttonPoll,
         .responseFn = buttonResponse,
+        .appContext = NULL,
     };
     appID = schedRegisterApp(&config);
     if (appID < 0) {
@@ -44,7 +45,7 @@ bool buttonInit()
 }
 
 // Poller
-void buttonPoll(int appID, int state)
+void buttonPoll(int appID, int state, void *appContext)
 {
 
     // Switch based upon state
@@ -74,7 +75,7 @@ void buttonPoll(int appID, int state)
 }
 
 // Interrupt handler
-void buttonISR(int appID, uint16_t pins)
+void buttonISR(int appID, uint16_t pins, void *appContext)
 {
 
     // Set the state to button, and immediately schedule
@@ -147,7 +148,7 @@ bool sendHealthLogMessage(bool immediate)
 }
 
 // Gateway Response handler
-void buttonResponse(int appID, J *rsp)
+void buttonResponse(int appID, J *rsp, void *appContext)
 {
 
     // If this is a response timeout, indicate as such

--- a/Application/Sensor/ping.c
+++ b/Application/Sensor/ping.c
@@ -31,9 +31,9 @@ static bool templateRegistered = false;
 static int appID = -1;
 
 // Forwards
-static void pingISR(int appID, uint16_t pins);
-static void pingPoll(int appID, int state);
-static void pingResponse(int appID, J *rsp);
+static void pingISR(int appID, uint16_t pins, void *appContext);
+static void pingPoll(int appID, int state, void *appContext);
+static void pingResponse(int appID, J *rsp, void *appContext);
 static bool sendHealthLogMessage(bool immediate);
 #if !SURVEY_MODE
 static void addNote(uint32_t count);
@@ -53,6 +53,7 @@ bool pingInit()
         .interruptFn = pingISR,
         .pollFn = pingPoll,
         .responseFn = pingResponse,
+        .appContext = NULL,
     };
     appID = schedRegisterApp(&config);
     if (appID < 0) {
@@ -65,7 +66,7 @@ bool pingInit()
 }
 
 // Poller
-void pingPoll(int appID, int state)
+void pingPoll(int appID, int state, void *appContext)
 {
 
     // Switch based upon state
@@ -119,7 +120,7 @@ void pingPoll(int appID, int state)
 }
 
 // Interrupt handler
-void pingISR(int appID, uint16_t pins)
+void pingISR(int appID, uint16_t pins, void *appContext)
 {
 
     // Set the state to button, and immediately schedule
@@ -269,7 +270,7 @@ static void addNote(uint32_t count)
 #endif
 
 // Gateway Response handler
-void pingResponse(int appID, J *rsp)
+void pingResponse(int appID, J *rsp, void *appContext)
 {
 
     // If this is a response timeout, indicate as such

--- a/Application/Sensor/pir.c
+++ b/Application/Sensor/pir.c
@@ -28,9 +28,9 @@ static uint32_t motionEventsTotal = 0;
 static int appID = -1;
 
 // Forwards
-static void pirISR(int appID, uint16_t pins);
-static void pirPoll(int appID, int state);
-static void pirResponse(int appID, J *rsp);
+static void pirISR(int appID, uint16_t pins, void *appContext);
+static void pirPoll(int appID, int state, void *appContext);
+static void pirResponse(int appID, J *rsp, void *appContext);
 static void addNote(bool immediate);
 static bool registerNotefileTemplate(void);
 static void resetInterrupt(void);
@@ -48,6 +48,7 @@ bool pirInit()
         .interruptFn = pirISR,
         .pollFn = pirPoll,
         .responseFn = pirResponse,
+        .appContext = NULL,
     };
     appID = schedRegisterApp(&config);
     if (appID < 0) {
@@ -208,7 +209,7 @@ void resetInterrupt()
 }
 
 // Poller
-void pirPoll(int appID, int state)
+void pirPoll(int appID, int state, void *appContext)
 {
 
     // Disable if this isn't a reference sensor
@@ -288,7 +289,7 @@ static bool registerNotefileTemplate()
 }
 
 // Gateway Response handler
-void pirResponse(int appID, J *rsp)
+void pirResponse(int appID, J *rsp, void *appContext)
 {
 
     // If this is a response timeout, indicate as such
@@ -352,7 +353,7 @@ static void addNote(bool immediate)
 }
 
 // Interrupt handler
-void pirISR(int appID, uint16_t pins)
+void pirISR(int appID, uint16_t pins, void *appContext)
 {
 
     // Set the state to 'motion' and immediately schedule


### PR DESCRIPTION
This PR adds an `void *appContext` field to the `schedAppConfig` structure, and updates the callback methods accordingly. This allows the entire application context to be encapsulated, and passed throughout the system.

_____________________

**Rationale:**

Thinking of a "sensor" as an "application" and the scheduler as the core of the "application host", then the need for a coherent application context becomes clear.

Currently, the application context is encapsulated statically in the implementation of an application (i.e. `.c` file). This works well for single instance applications, but starts to become a limiting factor when multiple instances are desired (e.g. multiple sensors of the same type). Today, multiple instances can be accommodated by using the application identifier as an index into an array of internally held contexts. However, this implementation of multiple contexts is somewhat cumbersome and/or fragile.

Zooming out, it becomes obvious that application context is a valuable concept. Not only would such a concept improve the usability of the current implementation (in regard to multiple sensors of the same type), but it would provide significant flexibility -- such as that which is required to enable higher-level languages (e.g. C++).