### PR TITLE
fix: Infinite Loop in Applications

### DIFF
--- a/Application/Sensor/button.c
+++ b/Application/Sensor/button.c
@@ -52,7 +52,7 @@ void buttonPoll(int appID, int state, void *appContext)
 
     // Immediately deactivate - nothing to do
     case STATE_ACTIVATED:
-        schedSetCompletionState(appID, STATE_DEACTIVATED, STATE_DEACTIVATED);
+        schedSetState(appID, STATE_DEACTIVATED, "button: nothing to do");
         break;
 
     // When a button is pressed, send a log message

--- a/Application/Sensor/ping.c
+++ b/Application/Sensor/ping.c
@@ -78,7 +78,7 @@ void pingPoll(int appID, int state, void *appContext)
 
 #if SURVEY_MODE
 
-        schedSetCompletionState(appID, STATE_DEACTIVATED, STATE_DEACTIVATED);
+        schedSetState(appID, STATE_DEACTIVATED, "ping: nothing to do");
         break;
 
 #else


### PR DESCRIPTION
- Button
- Ping

Applications were setting a completion state, without sending a
request to be completed. The appropriate course of action is to
set the state immediately, so the application will be deactivated.