### PR TITLE
chore: PIR independence

### DIFF
--- a/Application/Sensor/bme.c
+++ b/Application/Sensor/bme.c
@@ -53,21 +53,6 @@ static void bmeResponse(int appID, J *rsp, void *appContext);
 bool bmeInit()
 {
 
-    // Register the app
-    schedAppConfig config = {
-        .name = "bme",
-        .activationPeriodSecs = 60 * 60,
-        .pollPeriodSecs = 15,
-        .activateFn = NULL,
-        .interruptFn = NULL,
-        .pollFn = bmePoll,
-        .responseFn = bmeResponse,
-    };
-    appID = schedRegisterApp(&config);
-    if (appID < 0) {
-        return false;
-    }
-
     // Power on the sensor to see if it's here
     GPIO_InitTypeDef init = {0};
     init.Speed = GPIO_SPEED_FREQ_HIGH;
@@ -82,6 +67,23 @@ bool bmeInit()
     HAL_GPIO_WritePin(BME_POWER_GPIO_Port, BME_POWER_Pin, GPIO_PIN_RESET);
     if (success) {
         appSetSKU(SKU_REFERENCE);
+    } else {
+        return false;
+    }
+
+    // Register the app
+    schedAppConfig config = {
+        .name = "bme",
+        .activationPeriodSecs = 60 * 60,
+        .pollPeriodSecs = 15,
+        .activateFn = NULL,
+        .interruptFn = NULL,
+        .pollFn = bmePoll,
+        .responseFn = bmeResponse,
+    };
+    appID = schedRegisterApp(&config);
+    if (appID < 0) {
+        return false;
     }
 
     // Done

--- a/Application/Sensor/pir.c
+++ b/Application/Sensor/pir.c
@@ -42,6 +42,7 @@ static void pirISR(int appID, uint16_t pins, void *appContext);
 static void pirPoll(int appID, int state, void *appContext);
 static void pirResponse(int appID, J *rsp, void *appContext);
 static void addNote(bool immediate);
+static inline bool isSparrowReferenceSensorBoard(void);
 static bool registerNotefileTemplate(void);
 static void resetInterrupt(void);
 
@@ -49,11 +50,8 @@ static void resetInterrupt(void);
 bool pirInit()
 {
 
-    // Do not attempt to initialize if this isn't a reference sensor
-    if (!MY_I2C2_Ping(BME280_I2C_ADDR_PRIM, BME280_I2C_TIMEOUT_MS, BME280_I2C_RETRY_COUNT)) {
-    } else if (!MY_I2C2_Ping(BME280_I2C_ADDR_SEC, BME280_I2C_TIMEOUT_MS, BME280_I2C_RETRY_COUNT)) {
-    } else {
-        // Not a Sparrow Reference Sensor Board
+    // Do not initialize if this isn't a Sparrow Reference Sensor Board
+    if (!isSparrowReferenceSensorBoard()) {
         return false;
     }
 
@@ -381,4 +379,25 @@ void pirISR(int appID, uint16_t pins, void *appContext)
         return;
     }
 
+}
+
+// We have no viable way of detecting whether or not the PIR sensor
+// hardware is present, so we use the presence of the BME280 as a proxy.
+bool isSparrowReferenceSensorBoard (void) {
+    bool result;
+
+    // Power on the sensor to see if it's here
+    GPIO_InitTypeDef init = {0};
+    init.Speed = GPIO_SPEED_FREQ_LOW;
+    init.Pin = BME_POWER_Pin;
+    init.Mode = GPIO_MODE_OUTPUT_PP;
+    init.Pull = GPIO_NOPULL;
+    HAL_GPIO_Init(BME_POWER_GPIO_Port, &init);
+    HAL_GPIO_WritePin(BME_POWER_GPIO_Port, BME_POWER_Pin, GPIO_PIN_SET);
+    MX_I2C2_Init();
+    result = (MY_I2C2_Ping(BME280_I2C_ADDR_PRIM, BME280_I2C_TIMEOUT_MS, BME280_I2C_RETRY_COUNT)
+           || MY_I2C2_Ping(BME280_I2C_ADDR_SEC, BME280_I2C_TIMEOUT_MS, BME280_I2C_RETRY_COUNT));
+    MX_I2C2_DeInit();
+
+    return result;
 }


### PR DESCRIPTION
Refactor BME and PIR applications init sequence
- PIR uses I2C ping to test for BME
- Silence warnings so Sparrow Essentials Board does not send spurious error messages