### PR TITLE
fix: Error message conversion specifier

### DIFF
--- a/Application/Sensor/bme.c
+++ b/Application/Sensor/bme.c
@@ -173,7 +173,7 @@ void bmeResponse(int appID, J *rsp, void *appContext)
     // See if there's an error
     char *err = JGetString(rsp, "err");
     if (err[0] != '\0') {
-        APP_PRINTF("sensor error response: %d\r\n", err);
+        APP_PRINTF("bme: gateway returned ERROR --> %s\r\n", err);
         return;
     }
 

--- a/Application/Sensor/bme.c
+++ b/Application/Sensor/bme.c
@@ -173,7 +173,7 @@ void bmeResponse(int appID, J *rsp, void *appContext)
     // See if there's an error
     char *err = JGetString(rsp, "err");
     if (err[0] != '\0') {
-        APP_PRINTF("bme: gateway returned ERROR --> %s\r\n", err);
+        APP_PRINTF("bme: gateway returned error: %s\r\n", err);
         return;
     }
 

--- a/Application/Sensor/button.c
+++ b/Application/Sensor/button.c
@@ -153,7 +153,7 @@ void buttonResponse(int appID, J *rsp, void *appContext)
     // See if there's an error
     char *err = JGetString(rsp, "err");
     if (err[0] != '\0') {
-        APP_PRINTF("button: gateway returned ERROR --> %s\r\n", err);
+        APP_PRINTF("button: gateway returned error: %s\r\n", err);
         return;
     }
 

--- a/Application/Sensor/button.c
+++ b/Application/Sensor/button.c
@@ -109,7 +109,7 @@ bool sendHealthLogMessage(bool immediate)
     }
 
     // Format the health message
-    char message[80];
+    char message[80] = {0};
     utilAddressToText(ourAddress, message, sizeof(message));
     if (sensorName[0] != '\0') {
         strlcat(message, " (", sizeof(message));

--- a/Application/Sensor/button.c
+++ b/Application/Sensor/button.c
@@ -153,7 +153,7 @@ void buttonResponse(int appID, J *rsp, void *appContext)
     // See if there's an error
     char *err = JGetString(rsp, "err");
     if (err[0] != '\0') {
-        APP_PRINTF("sensor error response: %d\r\n", err);
+        APP_PRINTF("button: gateway returned ERROR --> %s\r\n", err);
         return;
     }
 

--- a/Application/Sensor/ping.c
+++ b/Application/Sensor/ping.c
@@ -273,7 +273,7 @@ void pingResponse(int appID, J *rsp, void *appContext)
     // See if there's an error
     char *err = JGetString(rsp, "err");
     if (err[0] != '\0') {
-        APP_PRINTF("sensor error response: %d\r\n", err);
+        APP_PRINTF("ping: gateway returned ERROR --> %s\r\n", err);
         return;
     }
 

--- a/Application/Sensor/ping.c
+++ b/Application/Sensor/ping.c
@@ -273,7 +273,7 @@ void pingResponse(int appID, J *rsp, void *appContext)
     // See if there's an error
     char *err = JGetString(rsp, "err");
     if (err[0] != '\0') {
-        APP_PRINTF("ping: gateway returned ERROR --> %s\r\n", err);
+        APP_PRINTF("ping: gateway returned error: %s\r\n", err);
         return;
     }
 

--- a/Application/Sensor/ping.c
+++ b/Application/Sensor/ping.c
@@ -152,7 +152,7 @@ bool sendHealthLogMessage(bool immediate)
     }
 
     // Format the health message
-    char message[80];
+    char message[80] = {0};
     utilAddressToText(ourAddress, message, sizeof(message));
     if (sensorName[0] != '\0') {
         strlcat(message, " (", sizeof(message));

--- a/Application/Sensor/pir.c
+++ b/Application/Sensor/pir.c
@@ -296,7 +296,7 @@ void pirResponse(int appID, J *rsp, void *appContext)
     // See if there's an error
     char *err = JGetString(rsp, "err");
     if (err[0] != '\0') {
-        APP_PRINTF("sensor error response: %d\r\n", err);
+        APP_PRINTF("pir: gateway returned ERROR --> %s\r\n", err);
         return;
     }
 

--- a/Application/Sensor/pir.c
+++ b/Application/Sensor/pir.c
@@ -296,7 +296,7 @@ void pirResponse(int appID, J *rsp, void *appContext)
     // See if there's an error
     char *err = JGetString(rsp, "err");
     if (err[0] != '\0') {
-        APP_PRINTF("pir: gateway returned ERROR --> %s\r\n", err);
+        APP_PRINTF("pir: gateway returned error: %s\r\n", err);
         return;
     }
 


### PR DESCRIPTION
%d was used on the gateway error message log instead of %s also added clarity as to the application and origin of the error message