### PR TITLE
Increase LSE drive from low to medium-low

### DIFF
--- a/Application/Core/Src/main.c
+++ b/Application/Core/Src/main.c
@@ -138,7 +138,10 @@ void SystemClock_Config(void)
     RCC_ClkInitTypeDef RCC_ClkInitStruct = {0};
 
     // Configure LSE Drive Capability
-    __HAL_RCC_LSEDRIVE_CONFIG(RCC_LSEDRIVE_LOW);
+    // Changed to medium low 2.22.23 to meet the requirements of 
+    // AN2867 sections 3.3,3.4 and STM32WL55 DS13293
+    // Table 63. Low-speed external user clock characteristics
+    __HAL_RCC_LSEDRIVE_CONFIG(RCC_LSEDRIVE_MEDIUMLOW);
 
     // Configure the main internal regulator output voltage
     __HAL_PWR_VOLTAGESCALING_CONFIG(PWR_REGULATOR_VOLTAGE_SCALE1);

--- a/Application/Framework/note.c
+++ b/Application/Framework/note.c
@@ -13,7 +13,7 @@ bool noteI2CReset(uint16_t DevAddress);
 const char *noteI2CTransmit(uint16_t DevAddress, uint8_t* pBuffer, uint16_t Size);
 const char *noteI2CReceive(uint16_t DevAddress, uint8_t* pBuffer, uint16_t Size, uint32_t *available);
 void noteDelay(uint32_t ms);
-long unsigned int noteMillis(void);
+uint32_t noteMillis(void);
 void noteBeginTransaction(void);
 void noteEndTransaction(void);
 
@@ -137,9 +137,9 @@ void noteDelay(uint32_t ms)
 }
 
 // Arduino-like millis() function
-long unsigned int noteMillis()
+uint32_t noteMillis()
 {
-    return (long unsigned int) TIMER_IF_GetTimeMs();
+    return (uint32_t) TIMER_IF_GetTimeMs();
 }
 
 // I2C reset procedure, called before any I/O and called again upon I/O error


### PR DESCRIPTION
Per AN2867 sections 3.3, 3.4, and STM32WL55 DS13293 table 63. LSE oscillator characteristics a setting of low is borderline for LSE stability, and changing to medium-low fixed LSE instability on some Truenotes.

The penalty is a 65nA increase in current consumption.

Also fix type mismatch in noteMillis()